### PR TITLE
Use entity manager to create non persistent entities.

### DIFF
--- a/src/main/java/org/terasology/workstation/system/ProcessPartWorkstationProcess.java
+++ b/src/main/java/org/terasology/workstation/system/ProcessPartWorkstationProcess.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.terasology.asset.Assets;
+import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.prefab.Prefab;
@@ -125,8 +126,9 @@ public class ProcessPartWorkstationProcess implements WorkstationProcess, Valida
 
     @Override
     public boolean isValid(EntityRef instigator, EntityRef workstation) {
-        EntityRef tempEntity = CoreRegistry.get(EntityManager.class).create();
-        tempEntity.setPersistent(false);
+        EntityManager entityManager = CoreRegistry.get(EntityManager.class);
+        EntityBuilder tempEntityBuilder = entityManager.newBuilder();
+        EntityRef tempEntity = tempEntityBuilder.build();
         for (ProcessPart part : processParts) {
             if (!part.validateBeforeStart(instigator, workstation, tempEntity)) {
                 return false;


### PR DESCRIPTION
It is just not more correct in terms of life cycle events but it is also needed for a future improvment of the autosaving.

The plan is to get rid of EntityRef#setPersistent so that it is simpler to just record the changes of non persistent entities.