### PR TITLE
feat!: Add Levels to workstation processes

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -1,7 +1,7 @@
 {
     "id" : "Workstation",
     "version" : "1.0.0-SNAPSHOT",
-    "author" : "Marcin Sciesinski <marcins78@gmail.com>, Josharias",
+    "author" : "Marcin Sciesinski <marcins78@gmail.com>, Josharias, XTariq",
     "displayName" : "Workstation",
     "description" : "",
     "dependencies" : [

--- a/src/main/java/org/terasology/workstation/component/ProcessDefinitionComponent.java
+++ b/src/main/java/org/terasology/workstation/component/ProcessDefinitionComponent.java
@@ -17,6 +17,14 @@ package org.terasology.workstation.component;
 
 import org.terasology.entitySystem.Component;
 
+/**
+ * Component that stores the definition of a workstation process. This definition contains the process type name, and
+ * the minimum process level necessary for doing this task.
+ */
 public class ProcessDefinitionComponent implements Component {
+    /** Type of the process. */
     public String processType;
+
+    /** Minimum level requirement of the process. */
+    public int processLevel;
 }

--- a/src/main/java/org/terasology/workstation/component/ProcessTypeDescriptionComponent.java
+++ b/src/main/java/org/terasology/workstation/component/ProcessTypeDescriptionComponent.java
@@ -19,4 +19,5 @@ import org.terasology.entitySystem.Component;
 
 public class ProcessTypeDescriptionComponent implements Component {
     public String name;
+    public int level;
 }

--- a/src/main/java/org/terasology/workstation/component/WorkstationComponent.java
+++ b/src/main/java/org/terasology/workstation/component/WorkstationComponent.java
@@ -21,8 +21,18 @@ import org.terasology.world.block.ForceBlockActive;
 
 import java.util.Map;
 
+/**
+ * This component stores information about all the process types this workstation supports. Specifically, this contains
+ * the names, max supported levels, and whether the process type is automated by this workstation.
+ */
 @ForceBlockActive
 public class WorkstationComponent implements Component {
+    /**
+     * This map stores all the processes that this workstation supports. The String (key) stores the process type name,
+     * while the WorkstationProcessType (key) stores the name/type and max supported level of the process, as well as
+     * whether this workstation automatically (true) or manually (false) performs the process.
+     */
     @Replicate
-    public Map<String, Boolean> supportedProcessTypes;
+    //public Map<WorkstationProcessType, Boolean> supportedProcessTypes;
+    public Map<String, WorkstationProcessType> supportedProcessTypes;
 }

--- a/src/main/java/org/terasology/workstation/component/WorkstationProcessType.java
+++ b/src/main/java/org/terasology/workstation/component/WorkstationProcessType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.workstation.component;
+
+import org.terasology.network.Replicate;
+import org.terasology.reflection.MappedContainer;
+
+/**
+ * This class stores information about a workstation process type. That is, a type or class of processes that can be
+ * performed at the appropriate workstations.
+ */
+@MappedContainer
+@Replicate
+public class WorkstationProcessType {
+    /** Name of the process type. */
+    @Replicate
+    public String processName;
+
+    /** The maximum level of this process type that this workstation supports up to. */
+    @Replicate
+    public int processLevel;
+
+    /** Indicates whether this process type can be performed automatically or not. */
+    @Replicate
+    public boolean isAutomatic;
+}

--- a/src/main/java/org/terasology/workstation/process/WorkstationProcess.java
+++ b/src/main/java/org/terasology/workstation/process/WorkstationProcess.java
@@ -23,6 +23,8 @@ public interface WorkstationProcess {
 
     String getProcessType();
 
+    int getProcessLevel();
+
     default String getProcessTypeName() {
         return getProcessType();
     }

--- a/src/main/java/org/terasology/workstation/system/ProcessPartWorkstationProcess.java
+++ b/src/main/java/org/terasology/workstation/system/ProcessPartWorkstationProcess.java
@@ -115,6 +115,11 @@ public class ProcessPartWorkstationProcess implements WorkstationProcess, Valida
     }
 
     @Override
+    public int getProcessLevel() {
+        return processDefinitionComponent.processLevel;
+    }
+
+    @Override
     public String getProcessTypeName() {
         return processTypeName;
     }

--- a/src/main/java/org/terasology/workstation/system/WorkstationAuthoritySystem.java
+++ b/src/main/java/org/terasology/workstation/system/WorkstationAuthoritySystem.java
@@ -30,6 +30,7 @@ import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.workstation.component.WorkstationComponent;
+import org.terasology.workstation.component.WorkstationProcessType;
 import org.terasology.workstation.component.WorkstationProcessingComponent;
 import org.terasology.workstation.event.WorkstationProcessRequest;
 import org.terasology.workstation.event.WorkstationStateChanged;
@@ -37,6 +38,7 @@ import org.terasology.workstation.process.InvalidProcessException;
 import org.terasology.workstation.process.WorkstationProcess;
 import org.terasology.world.block.BlockComponent;
 
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -159,7 +161,7 @@ public class WorkstationAuthoritySystem extends BaseComponentSystem implements U
     }
 
     private void processIfHasPendingAutomaticProcesses(EntityRef entity, WorkstationComponent workstation) {
-        Map<String, Boolean> possibleProcesses = new LinkedHashMap<>(workstation.supportedProcessTypes);
+        Map<String, WorkstationProcessType> possibleProcesses = new LinkedHashMap<>(workstation.supportedProcessTypes);
 
         // Filter out those currently processing
         WorkstationProcessingComponent processing = entity.getComponent(WorkstationProcessingComponent.class);
@@ -169,15 +171,24 @@ public class WorkstationAuthoritySystem extends BaseComponentSystem implements U
             }
         }
 
-        // Filter out non-automatic
-        for (Map.Entry<String, Boolean> processDef : workstation.supportedProcessTypes.entrySet()) {
-            if (!processDef.getValue()) {
+        // Filter out non-automatic processes.
+        for (Map.Entry<String, WorkstationProcessType> processDef : workstation.supportedProcessTypes.entrySet()) {
+            if (!processDef.getValue().isAutomatic) {
                 possibleProcesses.remove(processDef.getKey());
             }
         }
 
-        for (WorkstationProcess workstationProcess : workstationRegistry.getWorkstationProcesses(possibleProcesses.keySet())) {
-            if (possibleProcesses.get(workstationProcess.getProcessType())) {
+        /*
+        // Filter out non-automatic processes.
+        for (Map.Entry<WorkstationProcessType, Boolean> processDef : workstation.supportedProcessTypes.entrySet()) {
+            if (!processDef.getValue()) {
+                possibleProcesses.remove(processDef.getKey());
+            }
+        }
+        */
+
+        for (WorkstationProcess workstationProcess : workstationRegistry.getWorkstationProcesses(new ArrayList<WorkstationProcessType>(possibleProcesses.values()))) {
+            if (possibleProcesses.get(workstationProcess.getProcessType()) != null) { //TODO: Check again later after testing.
                 startProcessingAutomatic(entity, workstationProcess, time.getGameTimeInMs());
             }
         }

--- a/src/main/java/org/terasology/workstation/system/WorkstationFluidInventoryValidationSystem.java
+++ b/src/main/java/org/terasology/workstation/system/WorkstationFluidInventoryValidationSystem.java
@@ -23,12 +23,10 @@ import org.terasology.fluid.component.FluidInventoryComponent;
 import org.terasology.fluid.event.BeforeFluidPutInInventory;
 import org.terasology.registry.In;
 import org.terasology.workstation.component.WorkstationComponent;
+import org.terasology.workstation.component.WorkstationProcessType;
 import org.terasology.workstation.process.WorkstationProcess;
 import org.terasology.workstation.process.fluid.ValidateFluidInventoryItem;
 
-/**
- * @author Marcin Sciesinski <marcins78@gmail.com>
- */
 @RegisterSystem
 public class WorkstationFluidInventoryValidationSystem extends BaseComponentSystem {
     @In

--- a/src/main/java/org/terasology/workstation/system/WorkstationInventoryValidationSystem.java
+++ b/src/main/java/org/terasology/workstation/system/WorkstationInventoryValidationSystem.java
@@ -23,11 +23,9 @@ import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.logic.inventory.events.BeforeItemPutInInventory;
 import org.terasology.registry.In;
 import org.terasology.workstation.component.WorkstationComponent;
+import org.terasology.workstation.component.WorkstationProcessType;
 import org.terasology.workstation.process.WorkstationProcess;
 
-/**
- * @author Marcin Sciesinski <marcins78@gmail.com>
- */
 @RegisterSystem
 public class WorkstationInventoryValidationSystem extends BaseComponentSystem {
     @In

--- a/src/main/java/org/terasology/workstation/system/WorkstationRegistry.java
+++ b/src/main/java/org/terasology/workstation/system/WorkstationRegistry.java
@@ -15,8 +15,10 @@
  */
 package org.terasology.workstation.system;
 
+import org.terasology.workstation.component.WorkstationProcessType;
 import org.terasology.workstation.process.WorkstationProcess;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 public interface WorkstationRegistry {
@@ -24,7 +26,15 @@ public interface WorkstationRegistry {
 
     void registerProcess(String processType, WorkstationProcess workstationProcess);
 
+    void registerProcess(String processType, int processLevel, WorkstationProcess workstationProcess);
+
     Collection<WorkstationProcess> getWorkstationProcesses(Collection<String> processType);
 
+    Collection<WorkstationProcess> getWorkstationProcesses(ArrayList<WorkstationProcessType> processTypes);
+
+    Collection<WorkstationProcess> getWorkstationProcessesByLevel(ArrayList<WorkstationProcessType> processTypes);
+
     WorkstationProcess getWorkstationProcessById(Collection<String> supportedProcessTypes, String processId);
+
+    WorkstationProcess getWorkstationProcessByIdAndLevel(ArrayList<WorkstationProcessType> supportedProcessTypes, String processId);
 }

--- a/src/main/java/org/terasology/workstation/system/WorkstationRegistryImpl.java
+++ b/src/main/java/org/terasology/workstation/system/WorkstationRegistryImpl.java
@@ -24,8 +24,10 @@ import org.terasology.registry.In;
 import org.terasology.registry.InjectionHelper;
 import org.terasology.registry.Share;
 import org.terasology.workstation.component.ProcessDefinitionComponent;
+import org.terasology.workstation.component.WorkstationProcessType;
 import org.terasology.workstation.process.WorkstationProcess;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -34,7 +36,8 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * An implementation of a workstation registry to globally store all of the workstation process type names and
+ * workstation processes a game may have.
  */
 @RegisterSystem
 @Share(WorkstationRegistry.class)
@@ -42,15 +45,37 @@ public class WorkstationRegistryImpl extends BaseComponentSystem implements Work
     @In
     PrefabManager prefabManager;
 
+    /** A set of all process types that have been scanned in. */
     private Set<String> scannedTypes = new HashSet<>();
 
+    /**
+     * Outer string (key) is the processType like "BasicWoodcraftingProcess" or "BasicSmithingProcess".
+     * Inner string (key) is the ID for a WorkstationProcess.
+     * Inner WorkstationProcess (value) is the process for making an item (or similar). These tend to be the recipes for
+     * making items(?).
+     */
     private Map<String, Map<String, WorkstationProcess>> workstationProcesses = new LinkedHashMap<>();
 
+    /**
+     * Register all processes of a particular process type using the provided workstation process factory. The processes
+     * will be registered into the workstationProcesses map.
+     *
+     * @param processType   The name of the process type. For example, "BasicWoodcraftingProcess".
+     * @param factory       The factory that will be used to create all the individual processes.
+     */
     @Override
     public void registerProcessFactory(String processType, WorkstationProcessFactory factory) {
         registerProcesses(processType, factory);
     }
 
+    /**
+     * Return a collection of all the workstation processes that have the same workstation process type names as the
+     * ones provided. Note that this will not check to see if the level requirements are met.
+     *
+     * @param processTypes  A collection of Strings that contains the process type names being searched for.
+     * @return              A collection of workstation processes that match the process type names of the inputted
+     *                      processTypes.
+     */
     @Override
     public Collection<WorkstationProcess> getWorkstationProcesses(Collection<String> processTypes) {
         Map<String, WorkstationProcess> processes = new LinkedHashMap<>();
@@ -64,6 +89,72 @@ public class WorkstationRegistryImpl extends BaseComponentSystem implements Work
         return processes.values();
     }
 
+    /**
+     * Return a collection of all the workstation processes that are of the provided WorkstationProcessTypes. Note that
+     * this will not check to see if the level requirements are met.
+     *
+     * @param processTypes  The ArrayList of WorkstationProcessTypes that contains the supported process names and
+     *                      supported process levels or tiers. This is intended to be taken from a WorkstationComponent
+     *                      or similar class.
+     * @return              A collection of workstation processes that match the process name values of the given
+     *                      WorkstationProcessTypes.
+     */
+    @Override
+    public Collection<WorkstationProcess> getWorkstationProcesses(ArrayList<WorkstationProcessType> processTypes) {
+        Map<String, WorkstationProcess> processes = new LinkedHashMap<>();
+
+        for (int i = 0; i < processTypes.size(); i++) {
+            String processName = processTypes.get(i).processName;
+
+            if (!scannedTypes.contains(processName)) {
+                registerProcesses(processName, new ProcessPartWorkstationProcessFactory());
+            }
+            processes.putAll(workstationProcesses.get(processName));
+        }
+
+        return processes.values();
+    }
+
+    /**
+     * Return a collection of all the workstation processes that are of the provided WorkstationProcessTypes, and have a
+     * process level that's lower than or equal to the ones provided in the processTypes argument.
+     *
+     * @param processTypes  The ArrayList of WorkstationProcessTypes that contains the supported process type names and
+     *                      supported process levels or tiers. This is intended to be taken from a WorkstationComponent
+     *                      or similar class.
+     * @return              A collection of workstation processes that match the parameters of the given
+     *                      WorkstationProcessTypes. That is to say, they have the same process name, and are in the
+     *                      appropriate process level range.
+     */
+    @Override
+    public Collection<WorkstationProcess> getWorkstationProcessesByLevel(ArrayList<WorkstationProcessType> processTypes) {
+        Map<String, WorkstationProcess> processes = new LinkedHashMap<>();
+
+        for (int i = 0; i < processTypes.size(); i++) {
+            String processName = processTypes.get(i).processName;
+
+            if (!scannedTypes.contains(processName)) {
+                registerProcesses(processName, new ProcessPartWorkstationProcessFactory());
+            }
+
+            for (Map.Entry<String, WorkstationProcess> entry : workstationProcesses.get(processName).entrySet()) {
+                // Make sure that the workstation actually supports this process level, before adding it to the
+                // processes map.
+                if (processTypes.get(i).processLevel >= entry.getValue().getProcessLevel()) {
+                    processes.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        return processes.values();
+    }
+
+    /**
+     * Register the provided workstation process with a particular process type into the workstationProcesses map.
+     *
+     * @param processType           The name of the process type. For example, "BasicWoodcraftingProcess".
+     * @param workstationProcess    The workstation process to be registered.
+     */
     @Override
     public void registerProcess(String processType, WorkstationProcess workstationProcess) {
         Map<String, WorkstationProcess> processes = workstationProcesses.get(processType);
@@ -74,6 +165,36 @@ public class WorkstationRegistryImpl extends BaseComponentSystem implements Work
         processes.put(workstationProcess.getId(), workstationProcess);
     }
 
+    /**
+     * Register the provided workstation process with a particular process type into the workstationProcesses map.
+     * TODO: Could we just use the regular registerProcesses(String, WorkstationProcess) function?
+     * TODO: Could we just use the processType present in the workstationProcess itself, and remove the first arg?
+     * TODO: Should there be an extra check to ensure that the workstationProcess's processType is the same as the processType arg?
+     *
+     * @param processType           The name of the process type. For example, "BasicWoodcraftingProcess".
+     * @param processLevel          The level of the process. Likely unneeded.
+     * @param workstationProcess    The workstation process to be registered.
+     */
+    @Override
+    public void registerProcess(String processType, int processLevel, WorkstationProcess workstationProcess) {
+        Map<String, WorkstationProcess> processes = workstationProcesses.get(processType);
+        if (processes == null) {
+            processes = new HashMap<>();
+            workstationProcesses.put(processType, processes);
+        }
+        processes.put(workstationProcess.getId(), workstationProcess);
+    }
+
+    /**
+     * Find a workstation process that's been registered into this registry using a collection of possible process
+     * types as well as its processId.
+     *
+     * @param supportedProcessTypes A collection of Strings that contains the names of the process types being searched
+     *                              for.
+     * @param processId             The ID of the process.
+     * @return                      The workstation process that has a matching process type as well as process ID. If
+     *                              it doesn't exist, null is returned.
+     */
     @Override
     public WorkstationProcess getWorkstationProcessById(Collection<String> supportedProcessTypes, String processId) {
         for (WorkstationProcess workstationProcess : getWorkstationProcesses(supportedProcessTypes)) {
@@ -84,6 +205,36 @@ public class WorkstationRegistryImpl extends BaseComponentSystem implements Work
         return null;
     }
 
+    /**
+     * Find a workstation process that's been registered into this registry using an ArrayList of supported
+     * WorkstationProcessTypes (type names and max supported levels) as well as its processId. Unlike the
+     * {@link #getWorkstationProcessById(Collection, String)} method, this will also check to see if the process
+     * qualifies under the max level requirements.
+     *
+     * @param supportedProcessTypes The ArrayList of WorkstationProcessTypes that contains information on the supported
+     *                              process types. This is intended to be taken from a WorkstationComponent or similar
+     *                              class.
+     * @param processId             The ID of the process.
+     * @return                      The workstation process that has a matching process type, fits the level
+     *                              requirements, and has the same process ID. If it doesn't exist, null is returned.
+     */
+    public WorkstationProcess getWorkstationProcessByIdAndLevel(ArrayList<WorkstationProcessType> supportedProcessTypes, String processId) {
+        for (WorkstationProcess workstationProcess : getWorkstationProcessesByLevel(supportedProcessTypes)) {
+            if (workstationProcess.getId().equals(processId)) {
+                return workstationProcess;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Find and register all processes of a particular process type using the provided workstation process factory.
+     * The processes will be registered into the workstationProcesses map, and each process type will be added to the
+     * scannedTypes HashSet.
+     *
+     * @param processType   The name of the process type. For example, "BasicWoodcraftingProcess".
+     * @param factory       The factory that will be used to create all the individual processes.
+     */
     private void registerProcesses(String processType, WorkstationProcessFactory factory) {
         InjectionHelper.inject(factory);
         Map<String, WorkstationProcess> processes = new HashMap<>();

--- a/src/main/java/org/terasology/workstation/ui/ProcessListWidget.java
+++ b/src/main/java/org/terasology/workstation/ui/ProcessListWidget.java
@@ -22,8 +22,11 @@ import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.CoreWidget;
 import org.terasology.rendering.nui.layouts.ColumnLayout;
 import org.terasology.workstation.component.WorkstationComponent;
+import org.terasology.workstation.component.WorkstationProcessType;
 import org.terasology.workstation.process.WorkstationProcess;
 import org.terasology.workstation.system.WorkstationRegistry;
+
+import java.util.ArrayList;
 
 /**
  * Lists processes related to the passed in workstation
@@ -54,7 +57,7 @@ public class ProcessListWidget extends CoreWidget implements WorkstationUI {
         WorkstationComponent workstationComponent = workstation.getComponent(WorkstationComponent.class);
 
         columnLayout = new ColumnLayout();
-        for (WorkstationProcess process : workstationRegistry.getWorkstationProcesses(workstationComponent.supportedProcessTypes.keySet())) {
+        for (WorkstationProcess process : workstationRegistry.getWorkstationProcesses(new ArrayList<WorkstationProcessType>(workstationComponent.supportedProcessTypes.values()))) {
             // add a description of each process to the layout
             columnLayout.addWidget(new ProcessSummaryWidget(process));
         }


### PR DESCRIPTION
> ❗ BREAKING CHANGE: Changing workstation and process components requires major version change.

Added concept of levels to the Workstation module. Specifically, this means that workstations can now support a process type up to a certain maximum level, and processes can have a minimum level requirement before they can be performed. Now, multiple similar process types can be collapsed into one, and new item tiers can be more easily made.

To facilitate this, `WorkstationProcessType` was made, and several classes were modified to take into account levels. More testing still needs to be done.